### PR TITLE
Enable/Disable Polyscripting through a single MODE flag (or magic file)

### DIFF
--- a/php7.2/apache/.gitignore
+++ b/php7.2/apache/.gitignore
@@ -1,0 +1,1 @@
+wordpress

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -45,8 +45,6 @@ RUN a2enmod rewrite expires
 WORKDIR $PHP_SRC_PATH
 RUN make install
 
-VOLUME /var/www/html
-
 ENV WORDPRESS_VERSION 4.9.8
 ENV WORDPRESS_SHA1 0945bab959cba127531dceb2c4fed81770812b4f
 

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -41,6 +41,10 @@ RUN { \
 
 RUN a2enmod rewrite expires
 
+# Keep compiled layer up top so it is reused when scripts are modified.
+WORKDIR $PHP_SRC_PATH
+RUN make install
+
 VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 4.9.8
@@ -56,9 +60,6 @@ RUN set -ex; \
 
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY scramble.sh /usr/local/bin/
-
-WORKDIR $PHP_SRC_PATH
-RUN make install
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
 	chown -R www-data:www-data /usr/src/wordpress
 
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY scramble.sh /usr/local/bin/
 
 WORKDIR $PHP_SRC_PATH
 RUN make install

--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -40,10 +40,15 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		group="$(id -g)"
 	fi
 
+	if [ ! -d /wordpress ]; then
+	    echo "Please mount a directory at /wordpress where unscrambled wordpress can be saved. "
+	    echo "You may mount an empty directory and it will be auto-populated with WordPress."
+	    exit 1
+	fi
+
+    cd /wordpress
+
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		if  [ -x "$(command -v scramble.sh)" ]; then
-			scramble.sh
-		fi
 		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
 			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
@@ -72,6 +77,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			chown "$user:$group" .htaccess
 		fi
 	fi
+
+    if [ -e /usr/local/bin/scramble.sh ]; then
+        echo "Scrambler script found. Calling it..."
+        /usr/local/bin/scramble.sh
+    fi
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 

--- a/php7.2/apache/publish-image.sh
+++ b/php7.2/apache/publish-image.sh
@@ -7,8 +7,9 @@ headsha=$(git rev-parse --verify HEAD)
 
 
 docker build -t $image:$headsha .
-docker push $image:$headsha
-
-echo "Pushing as latest tag..."
 docker tag $image:$headsha $image:latest
-docker push $image:latest
+
+if [[ "$1" == "-p" ]]; then
+	docker push $image:$headsha
+	docker push $image:latest
+fi

--- a/php7.2/apache/run.sh
+++ b/php7.2/apache/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "$(date) Obtaining current git sha for tagging the docker image"
+headsha=$(git rev-parse --verify HEAD)
+
+docker run --name mysql-host -e MYSQL_ROOT_PASSWORD=qwerty -d mysql:5.7
+docker run --rm -e MODE=$MODE --name wordpress -v $PWD/wordpress:/wordpress  --link mysql-host:mysql -p 8000:80  polyverse/polyscripted-wordpress:$headsha

--- a/php7.2/apache/run.sh
+++ b/php7.2/apache/run.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+MODE=$1
+
+echo "Running under mode: $MODE"
+
 echo "$(date) Obtaining current git sha for tagging the docker image"
 headsha=$(git rev-parse --verify HEAD)
 

--- a/php7.2/apache/scramble.sh
+++ b/php7.2/apache/scramble.sh
@@ -1,21 +1,26 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 if [ ! -f "$PATH/s_php" ]; then
         cp /usr/local/bin/php /usr/local/bin/s_php
 fi
 
+rm -rf /var/www/html
 
-if [ "$MODE" == "polyscripted" ] || [ -e /polyscripted ]; then
-	
-	if [ -f /wordpress ]; then
-		cp /wordpress /usr/src/wordpress/
+if [[ "$MODE" == "polyscripted" || -f /polyscripted ]]; then
+
+	echo "===================== POLYSCRIPTING ENABLED =========================="
+	if [ -d /wordpress ]; then
+	    echo "Copying /wordpress to /var/www/html to be polyscripted in place..."
+	    echo "This will prevent changes from being saved back to /wordpress, but will protect"
+	    echo "against code injection attacks..."
+		cp -R /wordpress /var/www/html
 	fi
 
 	echo "Starting polyscripted WordPress"
 	cd $POLYSCRIPT_PATH
-	sed -i "/#mod_allow/a \define( 'DISALLOW_FILE_MODS', true );" /usr/src/wordpress/wp-config.php
+	sed -i "/#mod_allow/a \define( 'DISALLOW_FILE_MODS', true );" /var/www/html/wp-config.php
     	./build-scrambled.sh
-	if [ -f scrambled.json ] && s_php tok-php-transformer.php -p /usr/src/wordpress --replace; then
+	if [ -f scrambled.json ] && s_php tok-php-transformer.php -p /var/www/html --replace; then
 		echo "Polyscripting enabled."
 		echo "done"
 	else
@@ -29,5 +34,5 @@ else
     echo "  2. OR create a file at path: /polyscripted"
 
     # Symlink the mount so it's editable
-    ln -s /wordpress /usr/src/wordpress
+    ln -s /wordpress /var/www/html
 fi

--- a/php7.2/apache/scramble.sh
+++ b/php7.2/apache/scramble.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 if [ ! -f "$PATH/s_php" ]; then
         cp /usr/local/bin/php /usr/local/bin/s_php
 fi
@@ -27,5 +29,5 @@ else
     echo "  2. OR create a file at path: /polyscripted"
 
     # Symlink the mount so it's editable
-    ln -s /wordpress /var/www/html
+    ln -s /wordpress /usr/src/wordpress
 fi

--- a/php7.2/apache/scramble.sh
+++ b/php7.2/apache/scramble.sh
@@ -1,0 +1,31 @@
+if [ ! -f "$PATH/s_php" ]; then
+        cp /usr/local/bin/php /usr/local/bin/s_php
+fi
+
+
+if [ "$MODE" == "polyscripted" ] || [ -e /polyscripted ]; then
+	
+	if [ -f /wordpress ]; then
+		cp /wordpress /usr/src/wordpress/
+	fi
+
+	echo "Starting polyscripted WordPress"
+	cd $POLYSCRIPT_PATH
+	sed -i "/#mod_allow/a \define( 'DISALLOW_FILE_MODS', true );" /usr/src/wordpress/wp-config.php
+    	./build-scrambled.sh
+	if [ -f scrambled.json ] && s_php tok-php-transformer.php -p /usr/src/wordpress --replace; then
+		echo "Polyscripting enabled."
+		echo "done"
+	else
+		echo "Polyscripting failed."
+		cp /usr/local/bin/s_php /usr/local/bin/php
+		exit 1
+	fi
+else
+    echo "Polyscripted mode is off. To enable it, either:"
+    echo "  1. Set the environment variable: MODE=polyscripted"
+    echo "  2. OR create a file at path: /polyscripted"
+
+    # Symlink the mount so it's editable
+    ln -s /wordpress /var/www/html
+fi


### PR DESCRIPTION
# WHAT

Wordpress is launched simply:
```
docker run --rm -e MODE=$MODE --name wordpress -v $PWD/wordpress:/wordpress  --link mysql-host:mysql -p 8000:80  polyverse/polyscripted-wordpress:$headsha
```

And depending on whether `$MODE=polyscripted` or not, the wordpress either launches in polyscripted mode, or regular mode.

# WHY

This has a few implications:
1. If you forget to do anything at all, wordpress works exactly as you would expect.
2. When in doubt, you can get back to normal
3. The /wordpress directory can be mounted on any non-polyverse container to just get rid of polyscripting instantly.
4. Enabling Polyscripting is transparent, trivial, and on any other containers, will simply be ignored.

# HOW

The procedure for this is very simple, and follows the decision tree as laid out below:

Step 1: Determine if Polyscripting is enabled by existence of the environment variable `$MODE=polyscripted`, OR by the existence of the file `/polyscripted`
* If YES -> Polyscripting Flow
* Otherwise -> Non-Polyscripting Flow

Non-Polyscripting Flow:

Step 1: Symbolic link `/wordpress`->`/var/www/html`

Now all wordpress changes automatically get saved to the externally mounted directory. It is wordpress as you know it. Plugins, upgrades, code generation, etc.

Polyscripting Flow:

Step 1: Copy recursively `/wordpress` -> `/var/www/html`

Step 2: Generate new language

Step 3: Transform `/var/www/html` to new language

Step 4: Replace original PHP interpreter with new language interpreter

Step 5: Launch wordpress.

Now any changes made to `/var/www/html` are isolated from `/wordpress`, and in addition, there is no interpreter that can interpret the plain old php under `/wordpress`, or any new injected php.
